### PR TITLE
revise fts.nav JS

### DIFF
--- a/src/assets/js/vendor/fts.nav.js
+++ b/src/assets/js/vendor/fts.nav.js
@@ -191,6 +191,10 @@
 
     $(w).on('resize', function() {
 
+      var targetTrigger = $('.nav-menu-toggle');
+      var targetId = targetTrigger.attr('aria-controls');
+      var targetZone = $('#' + targetId);
+
       if( Nav.isScreenSize( 'mediumscreen' ) || Nav.isScreenSize( 'smallscreen' ) ) {
 
         var parentMenu;
@@ -205,6 +209,10 @@
 
         }); // each menu with children
 
+        if ( targetZone.hasClass('was-expanded') ) {
+          targetZone.removeClass('was-expanded').attr('aria-expanded', 'true');
+        }
+
       } else {
 
         $('.menu-item.has-children').each(function() {
@@ -215,6 +223,16 @@
           Nav.destroySmallView( parentMenu, subMenu );
 
         }); // each menu with children
+
+      }
+
+      if ( targetZone.attr('aria-expanded') && Nav.isScreenSize( 'largescreen' ) ) {
+
+        if ( targetZone.attr('aria-expanded') === 'true' ) {
+          targetZone.addClass('was-expanded');
+        }
+
+        targetZone.removeAttr('aria-expanded');
 
       }
 

--- a/src/assets/js/vendor/fts.nav.js
+++ b/src/assets/js/vendor/fts.nav.js
@@ -209,8 +209,8 @@
 
         }); // each menu with children
 
-        if ( targetZone.hasClass('was-expanded') ) {
-          targetZone.removeClass('was-expanded').attr('aria-expanded', 'true');
+        if ( $('body').hasClass('nav-is-active') ) {
+          targetZone.attr('aria-expanded', 'true');
         }
 
       } else {
@@ -227,10 +227,6 @@
       }
 
       if ( targetZone.attr('aria-expanded') && Nav.isScreenSize( 'largescreen' ) ) {
-
-        if ( targetZone.attr('aria-expanded') === 'true' ) {
-          targetZone.addClass('was-expanded');
-        }
 
         targetZone.removeAttr('aria-expanded');
 


### PR DESCRIPTION
what this PR accomplishes is the issue where aria-expanded was an attribute on the navigation when moving up from small screen to large screen views, where the navigation was no longer an expandable/collapsable object.

The revision does the following:

on resize up to large screen, check to see if the navigation had an aria expanded attr of true.  if so, apply a class of was-expanded to the navigation.

whether the navigation had an aria-expanded of true or false, it still needed to be removed when in desktop mode, so now the attribute is completely removed.

when moving down to small screen view, if the navigation has the class 'was-expanded' remove that class and reset the aria-expanded to true
